### PR TITLE
Restore webpage symlinks for gh-pages site

### DIFF
--- a/webpage/images
+++ b/webpage/images
@@ -1,0 +1,1 @@
+v/latest/images

--- a/webpage/index.html
+++ b/webpage/index.html
@@ -1,0 +1,1 @@
+v/latest/index.html

--- a/webpage/manuscript.pdf
+++ b/webpage/manuscript.pdf
@@ -1,0 +1,1 @@
+v/latest/manuscript.pdf


### PR DESCRIPTION
Closes https://github.com/greenelab/manubot-rootstock/issues/143

This reverts the deleted webpage files by commit ec018b74379ab95772c8d536e90ce8c04196ef32.

These files are used by the gh-pages branch to display the manuscript.